### PR TITLE
[FIX] dream_internal_server error by refactoring async handling and updated retry mechanisms across generation services

### DIFF
--- a/app/clients/groqai_client.py
+++ b/app/clients/groqai_client.py
@@ -1,10 +1,9 @@
 import json
-from typing import Dict, Any
 
 from app.utils import logger
-from app.config import GroqAIConfig  # now using Groq configuration
+from app.config import GroqAIConfig
 
-from groq import Groq  # Import Groq client
+from groq import AsyncGroq
 
 
 # ------------------------------
@@ -12,8 +11,7 @@ from groq import Groq  # Import Groq client
 # ------------------------------
 class GroqAIClient:
     @staticmethod
-    def get_response(system_prompt: str, user_prompt: str) -> Dict[str, Any]:
-
+    async def get_response(system_prompt: str, user_prompt: str) -> str:
         # prepare the messages for the Groq chat completions API
         messages = [
             {"role": "system", "content": system_prompt},
@@ -21,10 +19,10 @@ class GroqAIClient:
         ]
 
         # instantiate the Groq client using API key from GroqAIConfig
-        groq_client = Groq(api_key=GroqAIConfig.GROQ_API_KEY)
+        groq_client = AsyncGroq(api_key=GroqAIConfig.GROQ_API_KEY)
 
         # call the Groq chat completions API with parameters from the configuration
-        completion = groq_client.chat.completions.create(
+        completion = await groq_client.chat.completions.create(
             model=GroqAIConfig.GROQ_MODEL,
             messages=messages,
             temperature=GroqAIConfig.GROQ_TEMPERATURE,

--- a/app/routes/route_dream_life.py
+++ b/app/routes/route_dream_life.py
@@ -112,8 +112,8 @@ class DreamLifeRoute:
         logger.debug(f"Received payload: {payload}")
 
         # Start dream using the service
-        # response = dream_life_generation_service.execute_task(payload=payload)
-        response = construct_sample_payload()
+        response = await dream_life_generation_service.execute_task(payload=payload)
+        # response = construct_sample_payload()
         return {
             "payload": response,
             "message": "Dream has been successfully completed!",

--- a/app/services/dream_life_generation_service.py
+++ b/app/services/dream_life_generation_service.py
@@ -1,8 +1,6 @@
 from typing import Dict, Any
-from app.utils import retry
 from app.services.validation_manager import ValidationManager
 from app.utils import id_generator
-from app.config import GeneralConfig
 from app.utils.constants import PAYLOAD_CATEGORY
 from .generators import (
     routine_generator,
@@ -26,8 +24,7 @@ class DreamLifeGenerationService:
         return cls._instance
 
     @staticmethod
-    @retry(max_retries=GeneralConfig.RETRY_COUNT, delay=1, backoff=2)
-    def execute_task(payload: Dict[str, str]) -> Any:
+    async def execute_task(payload: Dict[str, str]) -> Any:
         """
         Executes a task by validating the request,
         interacting with the GroqAIClient to generate a Dream Life,
@@ -41,9 +38,11 @@ class DreamLifeGenerationService:
 
         # TODO: Rename *_generator to some other meaningful name, generator name belongs to py generator
         dream_life = {
-            "routine": routine_generator.generate(payload),
-            "fear_and_motivation": fear_and_motivation_generator.generate(payload),
-            "daily_habit": daily_habit_generator.generate(payload),
+            "routine": await routine_generator.generate(payload),
+            "fear_and_motivation": await fear_and_motivation_generator.generate(
+                payload
+            ),
+            "daily_habit": await daily_habit_generator.generate(payload),
         }
 
         # add IDs & return it

--- a/app/services/generators/fear_and_motivation_generator.py
+++ b/app/services/generators/fear_and_motivation_generator.py
@@ -9,6 +9,8 @@ from app.utils.constants import PROMPT_TYPE, PROMPT_CATEGORY, PAYLOAD_CATEGORY
 import json
 import os
 from app.services.validation_manager import ValidationManager
+from app.utils import retry
+from app.config import GeneralConfig
 
 
 # ------------------------------
@@ -60,13 +62,13 @@ class FearAndMotivationGenerator(BaseGenerator):
     ) -> None:
         ValidationManager(validation_type=payload_type).validate(payload)
 
-    def generate(self, payload: Dict[str, Any]) -> Any:
+    @retry(max_retries=GeneralConfig.RETRY_COUNT, delay=1, backoff=2)
+    async def generate(self, payload: Dict[str, Any]) -> Any:
         # load the output-schema for system prompt from JSON file
         parent_path = os.path.dirname(__file__).split("/")[:-2]
         relative_schema_path = ["schema", "fears_and_motivation_schema.json"]
         parent_path.extend(relative_schema_path)
         schema_path = "/".join(parent_path)
-        print(f"==>> schema_path: {schema_path}")
 
         with open(schema_path, "r", encoding="utf-8") as f:
             output_schema = json.load(f)
@@ -85,7 +87,7 @@ class FearAndMotivationGenerator(BaseGenerator):
             schema={"USER_DATA": payload},
         )
 
-        raw_output = GroqAIClient.get_response(
+        raw_output = await GroqAIClient.get_response(
             system_prompt=system_prompt, user_prompt=user_prompt
         )
 


### PR DESCRIPTION
- Replaced `Groq` with `AsyncGroq` in `groqai_client`
- Added `await` to dream life generation service call in dream route
- Removed retry mechanism from `execute_task` method in dream life generation service
- Added retry mechanism to `generate` method in daily habit generator
- Added retry mechanism to `generate` method in fear and motivation generator
- Added retry mechanism to `generate` method in routine generator