### PR TITLE
Enhance FastAPI configuration with metadata and expose Swagger UI via custom route

### DIFF
--- a/app/framework/fastapi_app.py
+++ b/app/framework/fastapi_app.py
@@ -1,10 +1,15 @@
-from fastapi import FastAPI, Request, Response
-import uvicorn
+from fastapi import FastAPI, Request, Response  # used in some other files
+import uvicorn  # used in some other files
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 # Create FastAPI app instance
-app = FastAPI()
+app = FastAPI(
+    title="DREAM",
+    description="Dynamic Realization Engine for Achieving Milestones",
+    version="1.0.0",
+    openapi_version="1.0.0",
+)
 
 # Expose FastAPI framework components
 App = app
@@ -12,7 +17,9 @@ App = app
 # Configure CORS
 App.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Or specify origins like ["https://example.com"]
+    allow_origins=[
+        "*"
+    ],  # specify origin for frontend like ["https://finddreamlife.com"]
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allow_headers=[
@@ -31,3 +38,8 @@ App.add_middleware(
 @App.get("/")
 def read_root():
     return {"message": "FastAPI CORS-configured app"}
+
+
+@App.get("/openapi.json")
+def get_openapi():
+    return JSONResponse(content=app.openapi())


### PR DESCRIPTION
* Included the **title**, **description**, **version**, and **OpenAPI version** in the FastAPI application configuration.
* Added a new `get_openapi` route to serve the **Swagger UI** on the **frontend**.